### PR TITLE
Build in all branches and use caching in GitHub Actions

### DIFF
--- a/.github/workflows/build-non-production.yml
+++ b/.github/workflows/build-non-production.yml
@@ -1,8 +1,9 @@
-name: Build and deploy production site
+name: Build and test
 
+# Run this workflow for all other branches than the production branch.
 on:
   push:
-    branches:
+    branches-ignore:
       - production-site
 
 jobs:
@@ -36,14 +37,3 @@ jobs:
 
       - name: Build site
         run: npm run build
-
-      - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-central-1
-
-      - name: Copy files to the production website with the AWS CLI
-        run: |
-          aws s3 sync _site s3://www2-eleventy.petey952.be --delete


### PR DESCRIPTION
Build in all branches to verify build passes. Use caching in GitHub Actions.

Fixes #5