### PR TITLE
Content-Type as allowed header in CORS

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -26,6 +26,10 @@ export class InfraStack extends cdk.Stack {
       'http://localhost:8080',
       `http://${recordName}.${domainName}`,
     ];
+    const corsAllowedHeaders = [
+      'Authorization',
+      'Content-Type',
+    ];
 
     this.webSiteBucket = new s3.Bucket(this, 'Www2EleventyWebBucket', {
       autoDeleteObjects: false,
@@ -70,7 +74,7 @@ export class InfraStack extends cdk.Stack {
       apiName: `Www2EleventyBackend`,
       corsPreflight: {
           allowCredentials: true,
-          allowHeaders: ['Authorization'],
+          allowHeaders: corsAllowedHeaders,
           allowMethods: [
             apigw.CorsHttpMethod.GET,
             apigw.CorsHttpMethod.POST,

--- a/infra/test/__snapshots__/infra.test.ts.snap
+++ b/infra/test/__snapshots__/infra.test.ts.snap
@@ -69,6 +69,7 @@ Object {
           "AllowCredentials": true,
           "AllowHeaders": Array [
             "Authorization",
+            "Content-Type",
           ],
           "AllowMethods": Array [
             "GET",


### PR DESCRIPTION
`Content-Type` must be allowed header in CORS preflight request/response.