### PR TITLE
Run infra and site workflows concurrently.

### DIFF
--- a/.github/workflows/build-non-production.yml
+++ b/.github/workflows/build-non-production.yml
@@ -7,8 +7,12 @@ on:
       - production-site
 
 jobs:
-  build-and-test:
+  build-and-test-infra:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: infra
 
     steps:
       - name: Checkout
@@ -21,20 +25,34 @@ jobs:
           cache: npm
           cache-dependency-path: |
             infra/package-lock.json
-            website/package-lock.json
 
       - name: Install infra dependencies
-        working-directory: infra
         run: npm ci
 
       - name: Test infra
-        working-directory: infra
         run: npm run test
 
-      - name: Install website dependencies
+  build-and-test-website:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
         working-directory: website
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: npm
+          cache-dependency-path: |
+            website/package-lock.json
+
+      - name: Install website dependencies
         run: npm ci
 
       - name: Build site
-        working-directory: website
         run: npm run build


### PR DESCRIPTION
To speed up GitHub Actions workflow throughput time, run infra and website workflows concurrently. Does not affect billed time, but we are not paying for this anyway.