### PR TITLE
Sort tags ascending.

### DIFF
--- a/website/.eleventy.js
+++ b/website/.eleventy.js
@@ -74,7 +74,7 @@ module.exports = function(eleventyConfig) {
       }
     }
 
-    return Array.from(distinctBlogPostTags);
+    return Array.from(distinctBlogPostTags).sort();
   });
 
   return {


### PR DESCRIPTION
Sort blog post tags ascending to always have them in same predictable order.